### PR TITLE
Have in-memory management store rely on IS registered client secrets

### DIFF
--- a/src/Management/Api/Akc.Duende.IdentityServer.Management.Api.Tests/ClientManagementPipelineTests.cs
+++ b/src/Management/Api/Akc.Duende.IdentityServer.Management.Api.Tests/ClientManagementPipelineTests.cs
@@ -224,6 +224,19 @@ namespace Akc.Duende.IdentityServer.Management.Api.Tests
                 });
         }
 
+        [Theory(DisplayName = "Fail when getting a client secret that does not exist")]
+        [Trait("Category", "CLIENT_SECRET")]
+        [InlineAutoData]
+        public async Task Test060(ClientCreateDto existingClient, CreateClientSecretDto clientSecret, string clientId)
+        {
+            _ = await Client.CreateClient(clientId, existingClient);
+
+            Func<Task> f = () => Client.GetClientSecret(clientId, clientSecret.Id);
+
+            await f.Should().ThrowAsync<HttpRequestException>()
+                .Where(e => e.StatusCode == HttpStatusCode.BadRequest);
+        }
+
         [Theory(DisplayName = "Pass when getting a client")]
         [Trait("Category", "CLIENT")]
         [InlineAutoData]

--- a/src/Management/Api/Akc.Duende.IdentityServer.Management.Api/SecretInternal.cs
+++ b/src/Management/Api/Akc.Duende.IdentityServer.Management.Api/SecretInternal.cs
@@ -4,26 +4,18 @@ using Duende.IdentityServer.Models;
 
 namespace Akc.Duende.IdentityServer.Management.Api
 {
-    internal class SecretInternal
+    internal class SecretInternal : Secret
     {
         public int Id { get; }
-        public string ClientId { get; }
-        public string? Description { get; }
-        public string Type { get; }
-        public string Value { get; }
-        public DateTime? Expiration { get; }
 
-        public SecretInternal(int id, string clientId, string type, string value, string description, DateTime? expiration)
+        public SecretInternal(int id, string type, string value, string description, DateTime? expiration)
+            : base(value, description, expiration)
         {
             Id = id;
-            ClientId = clientId;
             Type = type;
-            Value = value;
-            Description = description;
-            Expiration = expiration;
         }
 
-        public static SecretInternal FromModel(string clientId, Secret secret, int index) =>
-            new(index, clientId, secret.Type, secret.Value, secret.Description, secret.Expiration);
+        public static SecretInternal FromModel(Secret secret, int index) =>
+            new(index, secret.Type, secret.Value, secret.Description, secret.Expiration);
     }
 }


### PR DESCRIPTION
add test case when getting a client secret that does not exist